### PR TITLE
Fix summing of variance components in rptPoisson

### DIFF
--- a/R/rptPoisson.R
+++ b/R/rptPoisson.R
@@ -226,7 +226,7 @@ rptPoisson <- function(formula, grname, data, link = c("log", "sqrt"), CI = 0.95
                                 R_f_link <- var_f / var_p_link
                                 # origial scale
                                 if( adjusted) var_p_org <- EY * (exp(sum(var_VarComps)) - 1) + 1
-                                if(!adjusted) var_p_org <- EY * (exp(sum(var_VarComps + var_f)) - 1) + 1
+                                if(!adjusted) var_p_org <- EY * (exp(sum(var_VarComps) + var_f) - 1) + 1
                                 R_org <- EY * (exp(var_a) - 1)/ var_p_org
                                 R_f_org <- EY * (exp(var_f) - 1)/ var_p_org
                         }


### PR DESCRIPTION
In rptPoisson, the summing of the random components variance and the fixed effects variance has an issue, as the sum() parenthesis should not cover var_f. This is fixed in this pull request.